### PR TITLE
try find a ssl root certs file on linux

### DIFF
--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -178,6 +178,7 @@
             "/usr/local/ssl/lib/libssl.a",
             "/usr/local/ssl/lib/libcrypto.a"
           ],
+          "defines": ["_FIND_ROOT_CERTS=1"],
           "ldflags": [
             "-static-libstdc++"
           ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/nodegit",
   "description": "Node.js libgit2 asynchronous native bindings",
-  "version": "0.25.0-alpha.20",
+  "version": "0.25.0-alpha.21",
   "homepage": "http://github.com/elastic/nodegit",
   "keywords": [
     "libgit2",


### PR DESCRIPTION
https://github.com/elastic/code/issues/1329

This pr tries several common paths to find a root cert file and then set it to libgit's root store.

Note: this still won't resolve issues if a client's machine which has no openssl lib installed. 
( in a fresh docker image,
centos7: has certs
ubuntu: no
)
